### PR TITLE
fix: bump ga v2 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}
           path: .cache


### PR DESCRIPTION
Update breaking changes from GitHub Actions v2 to v4.

## Summary by Sourcery

CI:
- Bump actions/cache from v2 to v4 in .github/workflows/ci.yml